### PR TITLE
fix(date): date now display and parses correctly

### DIFF
--- a/src/FieldDefinitions/Date.js
+++ b/src/FieldDefinitions/Date.js
@@ -114,7 +114,7 @@ export class Date extends Component {
     className = !warn ? className : className + ' warn-required'
     const inputClass = warn ? 'warn-required' : ''
     placeholder = warn ? '* This Field Is Required' : placeholder
-    const formatValue = value => moment(value, 'M/D/YYYY')
+    const formatValue = value => moment(new Date(value)).format('M/D/YYYY')
 
     return (
       connectDropTarget(


### PR DESCRIPTION
This appears to be working now when linking to `bleu`