### PR TITLE
fix(Select): fix issue where select inputs cannot be cleared

### DIFF
--- a/src/FieldDefinitions/Select.js
+++ b/src/FieldDefinitions/Select.js
@@ -40,13 +40,16 @@ export class Select extends Component {
     handleCascadeKeywordClick(config)
   }
 
+  handleOnChange = () => {}
+
   onChange = e => {
-    const {config = {}, handleOnChange = () => null} = this.props
+    const {config = {}, handleOnChange = this.handleOnChange} = this.props
     const {name = null} = config
+    const value = e === null ? e = '' : e.value
     handleOnChange({
       target: {
         name,
-        value: e.value
+        value
       }
     })
   }


### PR DESCRIPTION
https://github.com/ClearC2/bleu/issues/1136

This PR fixes the bug where you cannot clear React-Select fields. The issue was caused by the react-select package not knowing how to handle `null` values. 

<img width="1080" alt="screen shot 2019-03-05 at 11 16 11 am" src="https://user-images.githubusercontent.com/25666355/53823879-416ea700-3f38-11e9-985f-18d5c6aa97d4.png">
