### PR TITLE
feat(add-menustyling-typeahead): add dynamic menu styling to typeahead

### DIFF
--- a/lib/FieldDefinitions/Typeahead.js
+++ b/lib/FieldDefinitions/Typeahead.js
@@ -470,10 +470,13 @@ var Typeahead = exports.Typeahead = function (_Component2) {
           _config$containerStyl = config.containerStyle,
           containerStyle = _config$containerStyl === undefined ? {} : _config$containerStyl,
           _config$iconStyle = config.iconStyle,
-          iconStyle = _config$iconStyle === undefined ? {} : _config$iconStyle;
+          iconStyle = _config$iconStyle === undefined ? {} : _config$iconStyle,
+          _config$menuStyle = config.menuStyle,
+          menuStyle = _config$menuStyle === undefined ? {} : _config$menuStyle;
 
       containerStyle = typeof containerStyle === 'string' ? JSON.parse(containerStyle) : containerStyle;
       labelStyle = typeof labelStyle === 'string' ? JSON.parse(labelStyle) : labelStyle;
+      menuStyle = typeof menuStyle === 'string' ? JSON.parse(menuStyle) : menuStyle;
       style = typeof style === 'string' ? JSON.parse(style) : style;
       iconStyle = typeof iconStyle === 'string' ? JSON.parse(iconStyle) : iconStyle;
       if (!name) return null;
@@ -551,6 +554,13 @@ var Typeahead = exports.Typeahead = function (_Component2) {
             minHeight: '25px',
             minWidth: '200px'
           }, style);
+        },
+        menu: function menu(base) {
+          return _extends({}, base, {
+            borderRadius: '1px',
+            height: '30px',
+            margin: 0
+          }, menuStyle);
         }
       });
 

--- a/src/FieldDefinitions/Typeahead.js
+++ b/src/FieldDefinitions/Typeahead.js
@@ -344,9 +344,10 @@ export class Typeahead extends Component {
       LinkIcon
     } = this.props
     const {name = null, required = false, multi = false, onKeyDown = () => null, allowcreate = false, link} = config
-    let {labelStyle = {}, style = {}, containerStyle = {}, iconStyle = {}} = config
+    let {labelStyle = {}, style = {}, containerStyle = {}, iconStyle = {}, menuStyle = {}} = config
     containerStyle = typeof containerStyle === 'string' ? JSON.parse(containerStyle) : containerStyle
     labelStyle = typeof labelStyle === 'string' ? JSON.parse(labelStyle) : labelStyle
+    menuStyle = typeof menuStyle === 'string' ? JSON.parse(menuStyle) : menuStyle
     style = typeof style === 'string' ? JSON.parse(style) : style
     iconStyle = typeof iconStyle === 'string' ? JSON.parse(iconStyle) : iconStyle
     if (!name) return null
@@ -418,6 +419,13 @@ export class Typeahead extends Component {
         minHeight: '25px',
         minWidth: '200px',
         ...style
+      }),
+      menu: (base) => ({
+        ...base,
+        borderRadius: '1px',
+        height: '30px',
+        margin: 0,
+        ...menuStyle
       })
     }
 


### PR DESCRIPTION
- Added menu style prop in the config to allow the menu container to be dynamically styled.