### PR TITLE
feat(conditions): add exclude checkbox

### DIFF
--- a/dist/cjs/Inputs/ConditionalDialog.js
+++ b/dist/cjs/Inputs/ConditionalDialog.js
@@ -231,6 +231,21 @@ var ConditionalDialog = function ConditionalDialog(props) {
                 options: inputTypeOptionsList()
               }
             }
+          }, {
+            type: 'field',
+            dimensions: {
+              x: 1,
+              y: 1,
+              h: 1,
+              w: 3
+            },
+            config: {
+              name: 'not',
+              label: 'Exclude Condition',
+              type: 'checkbox',
+              onValue: true,
+              offValue: false
+            }
           }]
         }
       },
@@ -517,6 +532,10 @@ var ConditionalDialog = function ConditionalDialog(props) {
       } else {
         values = (0, _immutable.fromJS)(e.target.value);
       }
+    }
+
+    if (e.target.name === 'not') {
+      newFieldValue = newFieldValue.set('not', e.target.value);
     }
 
     if (e.target.name === 'dynamicValues') {

--- a/dist/es/Inputs/ConditionalDialog.js
+++ b/dist/es/Inputs/ConditionalDialog.js
@@ -194,6 +194,21 @@ var ConditionalDialog = function ConditionalDialog(props) {
                 options: inputTypeOptionsList()
               }
             }
+          }, {
+            type: 'field',
+            dimensions: {
+              x: 1,
+              y: 1,
+              h: 1,
+              w: 3
+            },
+            config: {
+              name: 'not',
+              label: 'Exclude Condition',
+              type: 'checkbox',
+              onValue: true,
+              offValue: false
+            }
           }]
         }
       },
@@ -482,6 +497,10 @@ var ConditionalDialog = function ConditionalDialog(props) {
       }
     }
 
+    if (e.target.name === 'not') {
+      newFieldValue = newFieldValue.set('not', e.target.value);
+    }
+
     if (e.target.name === 'dynamicValues') {
       // newFieldValue = newFieldValue.set('condition', 'is one of')
       newFieldValue = newFieldValue.set('dynamicValues', e.target.value);
@@ -504,6 +523,7 @@ var ConditionalDialog = function ConditionalDialog(props) {
   var fieldsHeight = isBetweenCondition() ? fieldHeight * 3 : (nFieldsWithValues() + 2) * fieldHeight;
   var modalHeight = fieldsHeight + headerHeight + footerHeight + extraBodyHeight;
   var maxBodyHeight = maxModalHeight - headerHeight - footerHeight;
+  console.log('test');
   return React.createElement(Dialog, {
     size: {
       width: '800px',

--- a/src/Inputs/ConditionalDialog.js
+++ b/src/Inputs/ConditionalDialog.js
@@ -130,6 +130,17 @@ const ConditionalDialog = props => {
                   options: inputTypeOptionsList()
                 }
               }
+            },
+            {
+              type: 'field',
+              dimensions: {x: 1, y: 1, h: 1, w: 3},
+              config: {
+                name: 'not',
+                label: 'Exclude Condition',
+                type: 'checkbox',
+                onValue: true,
+                offValue: false
+              }
             }
           ]
         }
@@ -320,6 +331,9 @@ const ConditionalDialog = props => {
       } else {
         values = fromJS(e.target.value)
       }
+    }
+    if (e.target.name === 'not') {
+      newFieldValue = newFieldValue.set('not', e.target.value)
     }
     if (e.target.name === 'dynamicValues') {
       // newFieldValue = newFieldValue.set('condition', 'is one of')


### PR DESCRIPTION
This adds a new checkbox to the ConditionalDialog to exclude the condition. It adds a new key 'not' and sets it to true/false, per the backend api changes

<img width="614" alt="Screen Shot 2020-10-14 at 3 03 50 PM" src="https://user-images.githubusercontent.com/39033850/96039734-c2896200-0e2e-11eb-8419-ff03c2463f6f.png">
