### PR TITLE
fix(colorpicker): correct blur functionality on firefox

### DIFF
--- a/src/Inputs/Colorpicker/ColorInput.js
+++ b/src/Inputs/Colorpicker/ColorInput.js
@@ -43,7 +43,8 @@ const ColorInput = props => {
 
   const windowClickListener = useMemo(() => {
     return e => {
-      const insideClick = e.path.some(path => {
+      const pathHandler = (e.path || e.composedPath())
+      const insideClick = pathHandler.some(path => {
         return (
           path.id === inputId.current ||
           path.id === portalRef.current.state.id


### PR DESCRIPTION
The ```path``` property of ```Event``` objects is not implemented in Firefox. The standard equivalent in firefox is [composedPath](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) 
This is a correction to https://github.com/ClearC2/bleu/issues/3919