### PR TITLE
fix(reporting): is between date range filter fix

### DIFF
--- a/src/QueryBuilder/Where/ConditionalTable/ConditionalTable.js
+++ b/src/QueryBuilder/Where/ConditionalTable/ConditionalTable.js
@@ -192,16 +192,29 @@ export default class ConditionalTable extends Component {
         if (newValue.size > CONDITIONS[cond].maxFields) {
           newValue = newValue.slice(0, CONDITIONS[cond].maxFields)
         }
-        req.query.conditions.push({
-          name: key,
-          label: this.getLabel(key),
-          comparator: cond,
-          values: newValue,
-          dynamicValues: value.dynamicValues,
-          rawValues: rawValues,
-          not: value.not || false,
-          format: this.getFormat(key)
-        })
+        if (cond === 'is between') {
+          req.query.conditions.push({
+            name: key,
+            values: [newValue.get('0', '')],
+            comparator: 'is greater than'
+          })
+          req.query.conditions.push({
+            name: key,
+            values: [newValue.get('1', '')],
+            comparator: 'is less than'
+          })
+        } else {
+          req.query.conditions.push({
+            name: key,
+            label: this.getLabel(key),
+            comparator: cond,
+            values: newValue,
+            dynamicValues: value.dynamicValues,
+            rawValues: rawValues,
+            not: value.not || false,
+            format: this.getFormat(key)
+          })
+        }
       }
     })
     return req


### PR DESCRIPTION
In between filter was not working due to passing in the incorrect `conditions` format

**Original**
```
"conditions": [{
	"name": "createddate",
	"label": "Created Date",
	"comparator": "is between",
	"values": [
		"06/24/2020",
		"06/26/2020"
	],
	"not": false,
	"format": "date"
}]
```

**Fixed version**
```
"conditions": [{
		"name": "meta_createddate",
		"values": ["06/24/2020"],
		"comparator": "is greater than"
	},
	{
		"name": "meta_createddate",
		"values": ["06/26/2020"],
		"comparator": "is less than"
	}
]
```
