### PR TITLE
feat(conditional-predicate): add ability to create custom vals

### DIFF
--- a/dist/cjs/Inputs/ConditionalPredicate.js
+++ b/dist/cjs/Inputs/ConditionalPredicate.js
@@ -42,17 +42,19 @@ var _startsWith = _interopRequireDefault(require("@babel/runtime-corejs3/core-js
 
 var _concat = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/concat"));
 
-var _some = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/some"));
-
-var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/slicedToArray"));
-
 var _keys = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/object/keys"));
-
-var _forEach = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/for-each"));
 
 var _map = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/map"));
 
 var _filter = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/filter"));
+
+var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/slicedToArray"));
+
+var _forEach = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/for-each"));
+
+var _some = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/some"));
+
+var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/toConsumableArray"));
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -77,6 +79,27 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
   if (!propValue) {
     propValue = (0, _immutable.Map)();
   }
+
+  console.log(props);
+  var defaultCreatedInputOpts = (0, _toConsumableArray2.default)(props.keyword.options);
+  var propsVals = props.value.get('values').toJS();
+
+  if (propsVals.length) {
+    if ((0, _some.default)(propsVals).call(propsVals, function (val) {
+      return val.hasOwnProperty('__isNew__');
+    })) {
+      (0, _forEach.default)(propsVals).call(propsVals, function (val) {
+        if (val.hasOwnProperty('__isNew__')) {
+          defaultCreatedInputOpts.push(val);
+        }
+      });
+    }
+  }
+
+  var _useState = (0, _react.useState)(defaultCreatedInputOpts),
+      _useState2 = (0, _slicedToArray2.default)(_useState, 2),
+      createdInputOpts = _useState2[0],
+      setCreatedInputOpts = _useState2[1];
 
   function convertListToOptions(list) {
     var inputType = props.inputType.toLowerCase();
@@ -110,12 +133,12 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
     return convertListToOptions(options);
   }
 
-  var _useState = (0, _react.useState)((0, _immutable.Map)({
+  var _useState3 = (0, _react.useState)((0, _immutable.Map)({
     condition: inputTypeOptionsList()[0].value
   })),
-      _useState2 = (0, _slicedToArray2.default)(_useState, 2),
-      modalValues = _useState2[0],
-      setModalValues = _useState2[1];
+      _useState4 = (0, _slicedToArray2.default)(_useState3, 2),
+      modalValues = _useState4[0],
+      setModalValues = _useState4[1];
 
   (0, _react.useEffect)(function () {
     // const v = props.values[props.name]
@@ -409,6 +432,8 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
     delete extraFieldProps.value;
 
     if (fieldCount < nFieldsWithValues() + 1 && maxFieldCount > 0 && !modalValues.get('relative')) {
+      var isContains = props.value.getIn(['condition'], '') === 'contains';
+      var isIsOneOf = props.value.getIn(['condition'], '') === 'is one of';
       schema.form.jsonschema.layout.push({
         type: 'field',
         dimensions: {
@@ -425,6 +450,11 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
           label: "".concat(props.label),
           interactive: true,
           clearable: true,
+          keyword: {
+            category: props.keyword.category,
+            options: createdInputOpts
+          },
+          allowcreate: isContains || isIsOneOf,
           searchable: true,
           // I just added this line
           type: _SearchUtils.NUMERICAL_CONDITIONS.has(props.value.getIn(['condition'], '')) ? 'number' : props.inputType.toLowerCase(),
@@ -683,6 +713,17 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
         }
       } else {
         values = (0, _immutable.fromJS)(e.target.value);
+        var valArr = e.target.value;
+        var opts = (0, _toConsumableArray2.default)(createdInputOpts);
+
+        if (valArr.length) {
+          (0, _forEach.default)(valArr).call(valArr, function (val) {
+            if (val.hasOwnProperty('__isNew__')) {
+              opts.push(val);
+              setCreatedInputOpts(opts);
+            }
+          });
+        }
       }
     }
 

--- a/dist/es/Inputs/ConditionalPredicate.js
+++ b/dist/es/Inputs/ConditionalPredicate.js
@@ -13,12 +13,13 @@ import _defineProperty from "@babel/runtime-corejs3/helpers/esm/defineProperty";
 import _includesInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/includes";
 import _startsWithInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/starts-with";
 import _concatInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/concat";
-import _someInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/some";
-import _slicedToArray from "@babel/runtime-corejs3/helpers/esm/slicedToArray";
 import _Object$keys from "@babel/runtime-corejs3/core-js-stable/object/keys";
-import _forEachInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/for-each";
 import _mapInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/map";
 import _filterInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/filter";
+import _slicedToArray from "@babel/runtime-corejs3/helpers/esm/slicedToArray";
+import _forEachInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/for-each";
+import _someInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/some";
+import _toConsumableArray from "@babel/runtime-corejs3/helpers/esm/toConsumableArray";
 
 function ownKeys(object, enumerableOnly) { var keys = _Object$keys(object); if (_Object$getOwnPropertySymbols) { var symbols = _Object$getOwnPropertySymbols(object); if (enumerableOnly) symbols = _filterInstanceProperty(symbols).call(symbols, function (sym) { return _Object$getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -38,6 +39,29 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
   if (!propValue) {
     propValue = Map();
   }
+
+  console.log(props);
+
+  var defaultCreatedInputOpts = _toConsumableArray(props.keyword.options);
+
+  var propsVals = props.value.get('values').toJS();
+
+  if (propsVals.length) {
+    if (_someInstanceProperty(propsVals).call(propsVals, function (val) {
+      return val.hasOwnProperty('__isNew__');
+    })) {
+      _forEachInstanceProperty(propsVals).call(propsVals, function (val) {
+        if (val.hasOwnProperty('__isNew__')) {
+          defaultCreatedInputOpts.push(val);
+        }
+      });
+    }
+  }
+
+  var _useState = useState(defaultCreatedInputOpts),
+      _useState2 = _slicedToArray(_useState, 2),
+      createdInputOpts = _useState2[0],
+      setCreatedInputOpts = _useState2[1];
 
   function convertListToOptions(list) {
     var inputType = props.inputType.toLowerCase();
@@ -72,12 +96,12 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
     return convertListToOptions(options);
   }
 
-  var _useState = useState(Map({
+  var _useState3 = useState(Map({
     condition: inputTypeOptionsList()[0].value
   })),
-      _useState2 = _slicedToArray(_useState, 2),
-      modalValues = _useState2[0],
-      setModalValues = _useState2[1];
+      _useState4 = _slicedToArray(_useState3, 2),
+      modalValues = _useState4[0],
+      setModalValues = _useState4[1];
 
   useEffect(function () {
     // const v = props.values[props.name]
@@ -371,6 +395,8 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
     delete extraFieldProps.value;
 
     if (fieldCount < nFieldsWithValues() + 1 && maxFieldCount > 0 && !modalValues.get('relative')) {
+      var isContains = props.value.getIn(['condition'], '') === 'contains';
+      var isIsOneOf = props.value.getIn(['condition'], '') === 'is one of';
       schema.form.jsonschema.layout.push({
         type: 'field',
         dimensions: {
@@ -387,6 +413,11 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
           label: "".concat(props.label),
           interactive: true,
           clearable: true,
+          keyword: {
+            category: props.keyword.category,
+            options: createdInputOpts
+          },
+          allowcreate: isContains || isIsOneOf,
           searchable: true,
           // I just added this line
           type: NUMERICAL_CONDITIONS.has(props.value.getIn(['condition'], '')) ? 'number' : props.inputType.toLowerCase(),
@@ -644,6 +675,18 @@ var ConditionalPredicate = function ConditionalPredicate(props) {
         }
       } else {
         values = fromJS(e.target.value);
+        var valArr = e.target.value;
+
+        var opts = _toConsumableArray(createdInputOpts);
+
+        if (valArr.length) {
+          _forEachInstanceProperty(valArr).call(valArr, function (val) {
+            if (val.hasOwnProperty('__isNew__')) {
+              opts.push(val);
+              setCreatedInputOpts(opts);
+            }
+          });
+        }
       }
     }
 

--- a/src/Inputs/ConditionalPredicate.js
+++ b/src/Inputs/ConditionalPredicate.js
@@ -9,6 +9,18 @@ const ConditionalPredicate = props => {
   if (!propValue) {
     propValue = Map()
   }
+  const defaultCreatedInputOpts = [...props.keyword.options]
+  const propsVals = props.value.get('values').toJS()
+  if (propsVals.length) {
+    if (propsVals.some(val => val.hasOwnProperty('__isNew__'))) {
+      propsVals.forEach(val => {
+        if (val.hasOwnProperty('__isNew__')) {
+          defaultCreatedInputOpts.push(val)
+        }
+      })
+    }
+  }
+  const [createdInputOpts, setCreatedInputOpts] = useState(defaultCreatedInputOpts)
   function convertListToOptions (list) {
     const inputType = props.inputType.toLowerCase()
     if (inputType === 'number' || inputType === 'currency' || inputType === 'decimal') {
@@ -243,6 +255,8 @@ const ConditionalPredicate = props => {
     delete extraFieldProps.values
     delete extraFieldProps.value
     if (fieldCount < nFieldsWithValues() + 1 && maxFieldCount > 0 && !modalValues.get('relative')) {
+      const isContains = props.value.getIn(['condition'], '') === 'contains'
+      const isIsOneOf = props.value.getIn(['condition'], '') === 'is one of'
       schema.form.jsonschema.layout.push({
         type: 'field',
         dimensions: {x: 1, y: 2, h: calculateFieldHeight(props.inputType.toLowerCase()), w: 8},
@@ -255,6 +269,12 @@ const ConditionalPredicate = props => {
           label: `${props.label}`,
           interactive: true,
           clearable: true,
+          keyword: {
+            category: props.keyword.category,
+            default: '',
+            options: createdInputOpts
+          },
+          allowcreate: isContains || isIsOneOf,
           searchable: true, // I just added this line
           type: NUMERICAL_CONDITIONS.has(props.value.getIn(['condition'], '')) ? 'number' : props.inputType.toLowerCase(),// eslint-disable-line
           handleOnChange: dialogOnChange
@@ -427,6 +447,16 @@ const ConditionalPredicate = props => {
         }
       } else {
         values = fromJS(e.target.value)
+        const valArr = e.target.value
+        const opts = [...createdInputOpts]
+        if (valArr.length) {
+          valArr.forEach(val => {
+            if (val.hasOwnProperty('__isNew__')) {
+              opts.push(val)
+              setCreatedInputOpts(opts)
+            }
+          })
+        }
       }
     }
     if (e.target.name === 'dynamicValues') {


### PR DESCRIPTION
References https://github.com/ClearC2/bleu/issues/7916

Feature:
If condition is 'contains' or 'is one of', allow the bottom input to create custom values. 

Testing:
1. Go into Bleu, create a new report
2. Click Classification
3. When 'contains' or 'is one of' is selected, the 2nd input allows custom text creation. 
![image](https://user-images.githubusercontent.com/87039816/225121163-e25a992c-4c9f-459d-8223-ab85564764c7.png)
4. Add a couple new custom values and a couple static values from the dropdown
5. Click 'OK', open it back up and these options should persist. 
6. Click 'OK' and you should be able to see the values on the right side. 
7. Click 'Table' on the right, and confirm the values persist on the next screen and when hitting ' Edit Conditions' and going back to the input again.
8. From the reports dash page, confirm that when you click on a report, then go to the custom input, the values populate correctly. 