### PR TITLE
fix(native-select-indicator): increase the margin in native select indicator

### DIFF
--- a/src/styles/native-select.css
+++ b/src/styles/native-select.css
@@ -1,6 +1,6 @@
 .gfb-native-select-ios-down-indicator {
     margin-right: 6px !important;
-    margin-top: 5px;
+    margin-top: 10px;
     height: 14px !important;
     width: 14px !important;
     color: rgb(204, 204, 204);
@@ -8,7 +8,7 @@
 
 .gfb-native-select-android-down-indicator {
     margin-right: 6px;
-    margin-top: 4px;
+    margin-top: 10px;
     height: 14px;
     width: 14px;
     color: rgb(204, 204, 204);
@@ -16,7 +16,7 @@
 
 .gfb-native-select-web-down-indicator {
     margin-right: 6px;
-    margin-top: 4px;
+    margin-top: 10px;
     height: 14px;
     width: 14px;
     color: rgb(204, 204, 204);


### PR DESCRIPTION
To fix the off center native select indicator on mobile:
![image](https://github.com/user-attachments/assets/020b968f-6014-4f8b-b394-97a1ef36c8eb)
