### PR TITLE
fix(validationwarning): add default to destructured prop, removed commented line

### DIFF
--- a/src/Inputs/Input.js
+++ b/src/Inputs/Input.js
@@ -25,7 +25,7 @@ const Input = props => {
     onBlur,
     warning,
     'data-testid': testId = props?.name,
-    setHasValidationWarning
+    setHasValidationWarning = () => {}
   } = props
 
   const {

--- a/src/Inputs/core/InputContainer.js
+++ b/src/Inputs/core/InputContainer.js
@@ -88,7 +88,6 @@ const InputContainer = props => {
   const {cellInput = {}} = style
   const inputId = useRef(randomId())
   const {theme} = useTheme()
-  // const [hasValidationWarning, setHasValidationWarning] = useState(false)
   return (
     <div className='gfb-inner-cell-input' style={cellInput} data-tip data-for={inputId.current} css={theme.cellInput}>
       {!hasValidationWarning && <PortalTooltip id={inputId.current} message={inputTooltip} />}


### PR DESCRIPTION
Added this default because gfbinput does not go through inner cell which causes the destructured prop to be undefined an fail when calling GFBInput